### PR TITLE
Skip redirects from facebook.com & messenger.com

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -94,7 +94,7 @@ function extractRedirectTarget(url, targetParam = 'url') {
   // See if we can find a target in the URL.
   let target = findQueryParam(targetParam, url);
 
-  if (typeof target === 'string') {
+  if (typeof target === 'string' && target.startsWith('http')) {
     target = decodeURIComponent(target);
   }
   else {

--- a/extension/redirects.js
+++ b/extension/redirects.js
@@ -29,6 +29,15 @@ const KNOWN_REDIRECTS = [
     types: ["main_frame"]
   },
   {
+    name: 'Facebook',
+    targetParam: 'u',
+    patterns: [
+        '*://l.facebook.com/l.php?',
+        '*://l.messenger.com/l.php?'
+    ],
+    types: ["main_frame"]
+  },
+  {
     name: 'Amazon Affiliate',
     targetParam: 'location',
     patterns: [

--- a/extension/redirects.js
+++ b/extension/redirects.js
@@ -32,8 +32,8 @@ const KNOWN_REDIRECTS = [
     name: 'Facebook',
     targetParam: 'u',
     patterns: [
-        '*://l.facebook.com/l.php?',
-        '*://l.messenger.com/l.php?'
+      '*://l.facebook.com/l.php?',
+      '*://l.messenger.com/l.php?'
     ],
     types: ["main_frame"]
   },


### PR DESCRIPTION
Facebook uses a script called `l.php` to redirect all external links. I added a rule to `redirect.js` to detect and skip this.

Thanks for the great plugin 👍 