### PR TITLE
Resolve redirects when the contextmenu is opened (right click link). …

### DIFF
--- a/extension/common.js
+++ b/extension/common.js
@@ -14,44 +14,17 @@ function getOptionsFromStorage(cb, options) {
   return chrome.storage.sync.get(options, cb);
 }
 
+// eslint-disable-next-line no-unused-vars
+function wildcardMatch(text, pattern) {
+  pattern = pattern
+    .replace(/\*/g, '([^*]+)')
+  ;
+  let re = new RegExp(pattern, 'g');
+  return re.test(text);
+}
 
 // eslint-disable-next-line no-unused-vars
 function findQueryParam(targetParam, url) {
-  url = url || window.location.href;
-
-  if (!(targetParam && url)) {
-    return false;
-  }
-
-  // Find the first occurrance of '?' character. I've seen URLs that have embedded
-  // URLs that are not properly encoded, e.g.:
-  // https://www.google.com/url?hl=en&q=http://t.dd.delta.org/r/?id%3Dxxxxx,yyyyyy,zzzzz&source=gmail&ust=1516647918588000&usg=AFQjCNEV1C1cwHSrU8r1kyYmaPe4IAsb-Q
-  const queryIndex = url.indexOf('?');
-
-  if (queryIndex === -1) {
-    return false;
-  }
-
-  // Split the URL at the '?' to get the query string
-  const queryString = url.substr(queryIndex + 1);
-
-  // If we have a query string...
-  if (queryString) {
-
-    // Get the key/value pairs from the query string
-    const keyVals = queryString.split('&');
-    // Figure out how many pairs we have
-    const kvsLength = keyVals.length;
-    // For each iteration fo the loop
-    let kv;
-
-    for(let i=0; i < kvsLength; i++) {
-      // Get this key/value pair and split it up into its pieces
-      kv = keyVals[i].split('=');
-      // We are looking for "url=blahblahblah", so see if this is the one
-      if (kv[0] === targetParam) {
-        return kv[1];
-      }
-    }
-  }
+  url = new URL(url || window.location.href);
+  return url.searchParams.get(targetParam);
 }

--- a/extension/consts.js
+++ b/extension/consts.js
@@ -17,6 +17,7 @@ const DEFAULT_STRIPPING_METHOD                          = STRIPPING_METHOD_BLOCK
 
 const ACTION_RELOAD_AND_ALLOW_PARAMS                    = 'reload_and_allow_params';
 const ACTION_OPTIONS_SAVED                              = 'options_saved';
+const ACTION_APPLY_REDIRECTS                            = 'apply_redirects';
 
 // Need to be User-friendly looking as they're used for display purposes
 const CHANGE_TYPE_TRACKING_STRIP                        = 'Tracking Stripped';

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -18,6 +18,12 @@
       "background.js"
     ]
   },
+  "content_scripts": [
+    {
+      "matches": ["*://*/*"],
+      "js": ["tidy-clipboard-url.js"]
+    }
+  ],
   "permissions": [
     "storage",
     "tabs",

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -21,7 +21,7 @@
   "content_scripts": [
     {
       "matches": ["*://*/*"],
-      "js": ["tidy-clipboard-url.js"]
+      "js": ["resolve-copied-redirect.js"]
     }
   ],
   "permissions": [

--- a/extension/redirects.js
+++ b/extension/redirects.js
@@ -29,6 +29,15 @@ const KNOWN_REDIRECTS = [
     types: ["main_frame"]
   },
   {
+    name: 'Facebook',
+    targetParam: 'u',
+    patterns: [
+      '*://*.facebook.com/l.php',
+      '*://*.messenger.com/l.php',
+    ],
+    types: ["main_frame"]
+  },
+  {
     name: 'Amazon Affiliate',
     targetParam: 'location',
     patterns: [
@@ -102,7 +111,7 @@ KNOWN_REDIRECTS.forEach(KNOWN_REDIRECT => {
 
     // We need to generate a few variations on this original pattern
     // 1) support the URL param as the first param
-    newPatterns.push(`${originalPattern}${targetParamKv}`);
+    newPatterns.push(`${originalPattern}*`);
     // 2) suppor the URL param as a non-first param
     newPatterns.push(`${originalPattern}*&${targetParamKv}`);
   });

--- a/extension/resolve-copied-redirect.js
+++ b/extension/resolve-copied-redirect.js
@@ -1,0 +1,23 @@
+/* global
+
+  chrome
+*/
+'use strict';
+
+let getLinkElement = el => {
+  do {
+    if(el.href && el.href.startsWith('http')) {
+      return el;
+    }
+    el = el.parentNode;
+  } while(el !== null);
+};
+
+window.addEventListener('contextmenu', e => {
+  let target = getLinkElement(e.target);
+  if(target)
+    chrome.runtime.sendMessage(
+      {action: 'apply_redirects', url: target.href},
+      url => {target.href = url;}
+    );
+});


### PR DESCRIPTION
As described in https://github.com/newhouse/url-tracking-stripper/issues/28 this PR introduces a new feature: rewriting urls in the DOM when a context menu is opened. I tested this for facebook.com and messenger.com and works.

This PR requires a bit more testing before it is ready for merge.