### PR TITLE
Add Tradedoubler to redirects

### DIFF
--- a/assets/js/redirects.js
+++ b/assets/js/redirects.js
@@ -175,7 +175,7 @@ function replacePlaceholdersRegex(pattern) {
   pattern = pattern.replace(SCHEMA, 'http(s)?\:\\/\\/');
   pattern = pattern.replace(SUBDOMAIN, '([a-zA-z\-0-9]*\.)?');
   pattern = pattern.replace(PATH, '(\\/[\\w]+)+');
-  pattern = pattern.replace(QS_KVS, '([\\w]+\\=[\\w]+\\&)*');
+  pattern = pattern.replace(QS_KVS, '([\\w]*\\=?[\\w]*\\&)*');
   pattern = pattern.replace(QS_VALUE, '\\w');
 
   return pattern;

--- a/assets/js/redirects.js
+++ b/assets/js/redirects.js
@@ -72,6 +72,14 @@ const KNOWN_REDIRECTS = [
       `${SCHEMA}www.tkqlhce.com${PATH}?`
     ],
     types: ['main_frame']
+  },
+  {
+    name: 'Tradedoubler',
+    targetParam: 'url',
+    patterns: [
+      `${SCHEMA}${SUBDOMAIN}.tradedoubler.com/click?`
+    ],
+    types: ['main_frame']
   }
 ];
 

--- a/examples.js
+++ b/examples.js
@@ -26,6 +26,10 @@ const trackerExamples = [
 
 // STORE REDIRECT EXAMPLES
 const redirectExamples = [
+  {
+    fromm: 'http://clkde.tradedoubler.com/click?=&p=259740&a=2821835&g=0&url=https%3a%2f%2fwww.microsoft.com%2fen-us%2fstore%2fp%2fthe-witness%2fbx1wpt5rjsb2',
+    too: 'https://www.microsoft.com/en-us/store/p/the-witness/bx1wpt5rjsb2'
+  }
 ];
 
 // STORE REDIRECT WITH TRACKERS EXAMPLES


### PR DESCRIPTION
Does what it says on the tin. Tradedoubler has a ton of tracking methods, but this should catch most, if not all, of their outbound tracking links.