### PR TITLE
Add reddit to redirects

### DIFF
--- a/assets/js/redirects.js
+++ b/assets/js/redirects.js
@@ -72,6 +72,14 @@ const KNOWN_REDIRECTS = [
       `${SCHEMA}www.tkqlhce.com${PATH}?`
     ],
     types: ['main_frame']
+   },
+{
+    name: 'reddit',
+    targetParam: 'url',
+    patterns: [
+      `${SCHEMA}out.reddit.com${PATH}?`,
+    ],
+    types: ['main_frame']
   }
 ];
 

--- a/examples.js
+++ b/examples.js
@@ -26,6 +26,14 @@ const trackerExamples = [
 
 // STORE REDIRECT EXAMPLES
 const redirectExamples = [
+  {
+    fromm: 'https://out.reddit.com/t3_7jwyol?url=https%3A%2F%2Fexample.com%2Fexamplepath&token=some-UUID-like-token&app_name=reddit.com',
+    too: 'https://example.com/examplepath'
+  },
+  {
+    fromm: 'https://out.reddit.com/t3_8an64b?url=https%3A%2F%2Fexample.com%2Fanotherexamplepath&token=some-different-UUID-like-token&app_name=reddit.com',
+    too: 'https://example.com/anotherexamplepath',
+  }
 ];
 
 // STORE REDIRECT WITH TRACKERS EXAMPLES


### PR DESCRIPTION
Reddit at some point started capturing all requests leaving their site. I don't like it one bit. They display the target URL, but when you click, it passes through their tracker. Not very nice, no sir!