### PR TITLE
Adds `fbclib` to known tracking params

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,9 @@ Adobe Omniture SiteCatalyst
 - `ICID`
 - `icid`
 
+Facebook
+- `fbclid`
+
 Hubspot
 - `_hsenc`
 - `_hsmi`

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ and choose which one is right for you:
    - For even more privacy, I recommend the below "Block and Re-load + Skip Redirects" option below.
 
 3) __Block and Re-load + Skip Redirects__:
-   - This approach is nearly identicle to the above "Block And Re-load" Stripping Method.
+   - This approach is nearly identical to the above "Block And Re-load" Stripping Method.
    - However this one adds the __*most privacy*__ due to the fact that this method [Skips Known Redirects](#skip-known-redirects) that may track you via an intermediate page load - see below for more info.
 
 

--- a/assets/js/trackers.js
+++ b/assets/js/trackers.js
@@ -60,6 +60,8 @@ const TRACKERS_BY_ROOT = {
 
   // Non-prefixy and 1-offs
   '': [
+    // Facebook Click Identifier
+    'fbclid',
     // Google Click Identifier
     'gclid',
     // Unknown

--- a/examples.js
+++ b/examples.js
@@ -15,6 +15,10 @@ const hostEtc = 'https://foo.com/path/to/whatever';
 // SPECIFIC TRACKER EXAMPLES WE WANT TO ADD IN
 const trackerExamples = [
   {
+    fromm: 'https://mobile.twitter.com/rob_dodson/status/1054769558253256704?fbclid=IwAR1oP2nniRZt0LKF3DcjHWMBz1XYdRk7Q5S7RRldbCVc0zSPuHVWRlvmq2Q',
+    too: 'https://mobile.twitter.com/rob_dodson/status/1054769558253256704'
+  },
+  {
     fromm: 'https://stripe.com/blog/ending-bitcoin-support?utm_source=newsletter&utm_medium=email&utm_campaign=&stream=top-stories',
     too: 'https://stripe.com/blog/ending-bitcoin-support?stream=top-stories'
   },


### PR DESCRIPTION
Facebook recently started adding an [`fbclid` tracking parameter](http://thisinterestsme.com/facebook-fbclid-parameter/) to outbound links. This PR adds it to the list of known tracking parameters.

PS. If anyone building this on Node 10 on a Mac experiences a pile of crashes when running gulp, like I did, manually update the `natives` package to version `1.1.3`. See [this issue](https://github.com/gulpjs/gulp/issues/2162) for discussion.