### PR TITLE
add code.videolan.org to allowlist

### DIFF
--- a/assets/js/rules.js
+++ b/assets/js/rules.js
@@ -101,6 +101,13 @@ const DEFAULT_DOMAIN_RULES = [
     whitelist: ALL_TRACKERS,
   }),
   new DomainRule({
+    domainMatcher: new DomainMatcher('code.videolan.org', {
+      endsWith: true,
+    }),
+    blacklist: ['ref'],
+    whitelist: ALL_TRACKERS,
+  }),
+  new DomainRule({
     domainMatcher: new DomainMatcher('steampowered.com', {
       endsWith: true,
     }),


### PR DESCRIPTION
code.videolan.org is actually hosted on gitlab (enterprise version?)

e.g: https://code.videolan.org/videolan/vlc

so we need to add add code.videolan.org to the allowlist as gitlab